### PR TITLE
Fix Date time picker UI & tags 

### DIFF
--- a/components/DateTimePicker/CalendarDay.tsx
+++ b/components/DateTimePicker/CalendarDay.tsx
@@ -36,7 +36,8 @@ export const CalendarDay = ({
         type="button"
         className={cn(
           "flex items-center justify-center w-12 h-12 relative rounded-full transition-colors",
-          (isRangeStart || isRangeEnd) && "bg-gray-900 text-white",
+          isRangeEnd && "bg-gray-900 text-white",
+          isRangeStart && "bg-gray-400 text-white",
           !isCurrentMonth && "text-gray-300",
           isDisabled && "cursor-not-allowed"
         )}
@@ -45,7 +46,7 @@ export const CalendarDay = ({
         aria-label={`${day} ${new Intl.DateTimeFormat("en-US", {
           month: "long",
         }).format(new Date(year, month, 1))}, ${year}`}
-        aria-selected={isRangeStart || isRangeEnd}
+        aria-pressed={isRangeStart || isRangeEnd}
       >
         {day}
       </button>

--- a/components/DateTimePicker/DateTimePicker.tsx
+++ b/components/DateTimePicker/DateTimePicker.tsx
@@ -216,8 +216,8 @@ export default function DateTimePicker({
         {/* Date range inputs */}
         <div className="flex items-center mb-6">
           <div className="flex-1">
-            <div className="w-full border border-gray-300 rounded-lg p-4 bg-gray-100 text-left cursor-not-allowed">
-              <div className="text-gray-500 text-sm">
+            <div className="w-full border border-gray-300 rounded-lg p-4 text-left cursor-not-allowed">
+              <div className="text-gray-400 text-sm">
                 {formatDate(dateRange.startDate)}
               </div>
             </div>
@@ -241,9 +241,9 @@ export default function DateTimePicker({
         {/* Time range inputs */}
         <div className="flex items-center mb-8">
           <div className="flex-1">
-            <div className="w-full border border-gray-300 rounded-lg p-4 bg-gray-100 text-left cursor-not-allowed flex items-center gap-2">
+            <div className="w-full border border-gray-300 rounded-lg p-4 text-left cursor-not-allowed flex items-center gap-2">
               <ClockIcon />
-              <div className="text-gray-500 text-sm">{dateRange.startTime}</div>
+              <div className="text-gray-400 text-sm">Now</div>
             </div>
           </div>
 

--- a/components/Poll/PollForm.tsx
+++ b/components/Poll/PollForm.tsx
@@ -54,8 +54,9 @@ export default function PollForm() {
     "flex h-12 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm ring-offset-white outline-none file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-400 focus-visible:ring-1 focus-visible:ring-gray-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
   const handleTagKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
+      if (errors.tags) return;
       addTag(tagInput);
     } else if (
       e.key === "Backspace" &&

--- a/hooks/usePollForm.ts
+++ b/hooks/usePollForm.ts
@@ -30,7 +30,7 @@ export function usePollForm() {
   const currentDay = new Date().getDate();
 
   const today = new Date(currentYear, currentMonth, currentDay);
-  const nextWeek = new Date(currentYear, currentMonth, currentDay + 7);
+  const nextWeek = new Date(currentYear, currentMonth, currentDay + 6);
 
   // Form setup
   const form = useForm<PollFormData>({


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tag input now allows adding tags with both the Enter and Space keys in polls.

- **Bug Fixes**
  - Improved accessibility for calendar day buttons by updating ARIA attributes for better screen reader support.
  - Calendar day styling now visually distinguishes between the start and end of a selected date range.
  - Default end date for polls is now set to 6 days from today instead of 7.

- **Style**
  - Updated disabled start date and time input styles for better clarity, and changed the start time label to display "Now".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->