### PR TITLE
Fix: disable eruda tool on production enviroment

### DIFF
--- a/components/Eruda/eruda-provider.tsx
+++ b/components/Eruda/eruda-provider.tsx
@@ -5,7 +5,10 @@ import { ReactNode, useEffect } from "react";
 
 export const Eruda = (props: { children: ReactNode }) => {
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    if (
+      typeof window !== "undefined" &&
+      process.env.NODE_ENV !== "production"
+    ) {
       try {
         eruda.init();
       } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Restricted the initialization of the eruda debugging tool to non-production environments, ensuring it does not run in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->