### PR TITLE
fix: explore all polls order

### DIFF
--- a/components/Poll/PollList.tsx
+++ b/components/Poll/PollList.tsx
@@ -34,7 +34,7 @@ export default function PollList({
   const [sortBy, setSortBy] = useState<
     "creationDate" | "endDate" | "participantCount"
   >();
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">();
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   const handleSearch = (term: string) => {
     setSearchTerm(term);


### PR DESCRIPTION
- https://github.com/GeneralMagicio/worldview-be/issues/103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default sorting order for polls to display in descending order by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->